### PR TITLE
Fix failure when last_url not present

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,8 @@
 
 ## Unreleased
 
-- Minimum supported Ruby version updated to 3.2
+- Minimum supported Ruby version updated to 3.2.
+- Fix: Responses that don't have a `last_url` in the link no longer error.
 
 ## 1.0.1
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,9 @@
 
 ## Unreleased
 
-- Minimum supported Ruby version updated to 3.2.
+## 2.0.0
+
+- Changed: Minimum supported Ruby version updated to 3.2.
 - Fix: Responses that don't have a `last_url` in the link no longer error.
 
 ## 1.0.1

--- a/lib/git_hub_bub/response.rb
+++ b/lib/git_hub_bub/response.rb
@@ -74,6 +74,7 @@ module GitHubBub
 
     def last_page?
       return true if next_url.nil?
+      return false if last_url.nil? # A next page exists, but no "last" page, keep going.
       last_page_number = page_number_from_url(last_url)
       next_page_number = page_number_from_url(next_url)
       next_page_number > last_page_number

--- a/lib/git_hub_bub/version.rb
+++ b/lib/git_hub_bub/version.rb
@@ -1,3 +1,3 @@
 module GitHubBub
-  VERSION = "1.0.1"
+  VERSION = "2.0.0"
 end

--- a/test/git_hub_bub/response_test.rb
+++ b/test/git_hub_bub/response_test.rb
@@ -69,16 +69,16 @@ class ResponseTest < Test::Unit::TestCase
     data = {
       body: "[{\"url\":\"https://api.github.com/repos/puma/puma/issues/3643\"}]",
       headers: {
-        "Link" => "<https://api.github.com/repositories/2441517/issues?direction=desc&page=2&sort=comments&state=open&after=Y3Vyc29yOnYyOpIIzpU4Fek%3D&per_page=30>; rel=\"next\"",
+        "Link" => "<https://api.github.com/repositories/2441517/issues?direction=desc&page=2&sort=comments&state=open&after=Y3Vyc29yOnYyOpIIzpU4Fek%3D&per_page=30>; rel=\"next\""
       },
       status: 200
     }
     response = GitHubBub::Response.new(data)
 
-    assert_equal "https://api.github.com/repositories/2441517/issues?direction=desc&page=2&sort=comments&state=open&after=Y3Vyc29yOnYyOpIIzpU4Fek%3D&per_page=30", response.next_url
+    assert_equal "https://api.github.com/repositories/2441517/issues?direction=desc&page=2&sort=comments&state=open&after=Y3Vyc29yOnYyOpIIzpU4Fek%3D&per_page=30",
+      response.next_url
     assert_nil response.last_url
 
-    # This will fail because last_page? tries to parse last_url when it's nil
     refute response.last_page?
   end
 

--- a/test/git_hub_bub/response_test.rb
+++ b/test/git_hub_bub/response_test.rb
@@ -63,6 +63,25 @@ class ResponseTest < Test::Unit::TestCase
     end
   end
 
+  def test_last_page_with_next_but_no_last_url
+    # This reproduces a real response from the GitHub API where the Link header
+    # only contains rel="next" but no rel="last"
+    data = {
+      body: "[{\"url\":\"https://api.github.com/repos/puma/puma/issues/3643\"}]",
+      headers: {
+        "Link" => "<https://api.github.com/repositories/2441517/issues?direction=desc&page=2&sort=comments&state=open&after=Y3Vyc29yOnYyOpIIzpU4Fek%3D&per_page=30>; rel=\"next\"",
+      },
+      status: 200
+    }
+    response = GitHubBub::Response.new(data)
+
+    assert_equal "https://api.github.com/repositories/2441517/issues?direction=desc&page=2&sort=comments&state=open&after=Y3Vyc29yOnYyOpIIzpU4Fek%3D&per_page=30", response.next_url
+    assert_nil response.last_url
+
+    # This will fail because last_page? tries to parse last_url when it's nil
+    refute response.last_page?
+  end
+
   def test_rate_limit_sleep
     epoch_time = 1504196685
 


### PR DESCRIPTION
The `last_url` is not always available. From https://docs.github.com/en/rest/using-the-rest-api/using-pagination-in-the-rest-api?apiVersion=2022-11-28


> In some cases, only a subset of these links are available. For example, the link to the previous page won't be included if you are on the first page of results, and the link to the last page won't be included if it can't be calculated.

This causes failures reproduced in this test:

```
$ be rake test
...
Cause0: NoMethodError: undefined method 'to_str' for nil
/Users/rschneeman/.rubies/ruby-4.0.1/lib/ruby/4.0.0/uri/rfc3986_parser.rb:79:in 'URI::RFC3986_Parser#split'
/Users/rschneeman/.rubies/ruby-4.0.1/lib/ruby/4.0.0/uri/rfc3986_parser.rb:135:in 'URI::RFC3986_Parser#parse'
/Users/rschneeman/.rubies/ruby-4.0.1/lib/ruby/4.0.0/uri/common.rb:247:in 'URI.parse'
/Users/rschneeman/Documents/projects/git_hub_bub/lib/git_hub_bub/response.rb:88:in 'GitHubBub::Response#page_number_from_url'
/Users/rschneeman/Documents/projects/git_hub_bub/lib/git_hub_bub/response.rb:77:in 'GitHubBub::Response#last_page?'
/Users/rschneeman/Documents/projects/git_hub_bub/test/git_hub_bub/response_test.rb:82:in 'ResponseTest#test_last_page_with_next_but_no_last_url'
     79:     assert_nil response.last_url
     80:
     81:     # This will fail because last_page? tries to parse last_url when it's nil
  => 82:     refute response.last_page?
     83:   end
     84:
     85:   def test_rate_limit_sleep
============================================================================================================================================================================
====
E
============================================================================================================================================================================
====
Error: test_pagination(ResponseTest): NoMethodError: undefined method 'parse' for class CGI
/Users/rschneeman/Documents/projects/git_hub_bub/lib/git_hub_bub/response.rb:89:in 'GitHubBub::Response#page_number_from_url'
/Users/rschneeman/Documents/projects/git_hub_bub/lib/git_hub_bub/response.rb:77:in 'GitHubBub::Response#last_page?'
/Users/rschneeman/Documents/projects/git_hub_bub/test/git_hub_bub/response_test.rb:15:in 'ResponseTest#test_pagination'
     12:     assert_equal nil, response.prev_url
     13:     assert_equal nil, response.first_url
     14:
  => 15:     refute response.last_page?
     16:     assert response.first_page?
     17:
     18:     response = GitHubBub::Response.new(rails_issues_data(:second))
============================================================================================================================================================================
====
Finished in 0.03191 seconds.
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
----
15 tests, 34 assertions, 0 failures, 2 errors, 0 pendings, 0 omissions, 0 notifications
86.6667% passed
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
----
470.07 tests/s, 1065.50 assertions/s
rake aborted!
Command failed with status (1): [ruby -w -I"lib:lib:test" /Users/rschneeman/.rubies/ruby-4.0.1/lib/ruby/gems/4.0.0/gems/rake-13.3.1/lib/rake/rake_test_loader.rb "test/git_h
ub_bub/request_test.rb" "test/git_hub_bub/response_test.rb" "test/git_hub_bub/valid_token_test.rb" ]
/Users/rschneeman/.rubies/ruby-4.0.1/bin/bundle:25:in '<main>'
Tasks: TOP => test
```

A failing test was added and then fixed.